### PR TITLE
add new section 'What to use Josh for and when to use it'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ http://sdether.github.io/josh.js/
 * `history.js` - localStorage backed command history
 * `killring.js` - killring for kill & yank handling in readline
 
+##What to use Josh for and when to use it
+
+Josh allows developers to build their own command line interface to any sites. It supports full CLI Readline in the browser like TAB completion, emacs-style line editing, killring and history with reverse search.
+
 ## Tutorials
 * <a href="http://sdether.github.io/josh.js/helloworld.html">Hello world</a> - put a console on a web page and add a new custom command with completion
 * <a href="http://sdether.github.io/josh.js/quakeconsole.html">Quake Console</a> - Create a <em>quake</em>-style console with <code>ls</code>,


### PR DESCRIPTION
To make josh.js more approachable to a larger number of users—from informed developers to curious passersby and new and interested visitors—I have added a new section to the josh.js README. The section is entitled **What to Use Josh.js for and When to Use It**. As the name suggests, the new section, a brief paragraph, explains in plain and straightforward language what josh.js is used for and when one should use it.

Other repositories may begin to use this new informative and catchy section soon, as my colleagues contact open-source technologies in an effort to make them more accessible to the tens of thousands of new users learning to code and thousands joining GitHub every day.
